### PR TITLE
If there is no title specified, use the key name.

### DIFF
--- a/src/json.edit.js
+++ b/src/json.edit.js
@@ -1002,15 +1002,15 @@
             inputId = ns.id(fid + "-input", true),
             type = opts.type || getType(opts),
             input = priv.input(fid, type, inputId, opts, required, util),
-            result;
+            result,
+            labelText = opts.title || fid;
 
-        var label_text = opts.title || fid;
         result = {
             "div": {
                 "id": id,
                 "class": priv.genFieldClasses(fid, opts, " ", required),
                 "$childs": [
-                    priv.label(label_text, inputId),
+                    priv.label(labelText, inputId),
                     input
                 ]
             }


### PR DESCRIPTION
Small fix for not having to specify a title in the schema.
