### PR TITLE
use of deprecated select method

### DIFF
--- a/src/addons/tabs.js
+++ b/src/addons/tabs.js
@@ -45,7 +45,7 @@
                 priv.isEmptyConfig(val)) {
                 style = "display: none";
             } else if (firstVisible === null) {
-                firstVisible = id;
+                firstVisible = index;
             }
 
             return {
@@ -73,7 +73,7 @@
             container.tabs();
 
             if (firstVisible !== null) {
-                container.tabs("select", firstVisible);
+                container.tabs("option", "active", firstVisible);
             }
         });
 


### PR DESCRIPTION
jquery tabs has a select method that is deprecated for version 1.9+. I changed it to use option active instead.
