### PR TITLE
Fix for adding to an array which contains a nested array

### DIFF
--- a/src/json.edit.js
+++ b/src/json.edit.js
@@ -477,7 +477,7 @@
 
     function onAddItemClick(opts, id, i, name, util) {
         var
-            items = $("#" + id + " " + ns.$cls("array-items")),
+            items = $("#" + id + " > " + ns.$cls("array-items")),
             item = makeArrayItem(
                 opts,
                 name,
@@ -495,7 +495,7 @@
 
     function onClearItemsClick(opts, id) {
         var realMinItems = ifNotSet(opts.minItems, 0),
-            selectorItems = "#" + id + " " + ns.$cls("array-items"),
+            selectorItems = "#" + id + " > " + ns.$cls("array-items"),
             selectorChildsToRemove = ":not(:lt(" + realMinItems + "))";
 
         $(selectorItems).children(selectorChildsToRemove).remove();


### PR DESCRIPTION
Restrict selector to query for direct children when adding to or clearing an array property. Fixes a bug where adding to an array would append the object to a nested array, rather than at the desired level.
